### PR TITLE
Raise the exception to get a traceback

### DIFF
--- a/mongodb_migrations/cli.py
+++ b/mongodb_migrations/cli.py
@@ -61,7 +61,7 @@ class MigrationManager(object):
                     print(e.__class__)
                     if hasattr(e, 'message'):
                         print(e.message)
-                    sys.exit(1)
+                    raise
                 print("Succeed to upgrade version: %s" % self.migrations[migration_datetime])
                 self._create_migration(migration_datetime)
 
@@ -80,7 +80,7 @@ class MigrationManager(object):
                     print(e.__class__)
                     if hasattr(e, 'message'):
                         print(e.message)
-                    sys.exit(1)
+                    raise
                 print("Succeed to downgrade version: %s" % self.migrations[migration_datetime])
                 self._remove_migration(migration_datetime)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mongodb-migrations',
-    version='0.4.0',
+    version='0.4.1',
     description='A database migration tool for MongoDB',
     long_description=__doc__,
     url='https://github.com/DoubleCiti/mongodb-migrations',


### PR DESCRIPTION
If there is a syntax issue in the migration, its quite hard to catch just by using class and message.
Thus, dropping in a request to move them to raise the exception instead of doing sys.exit

Thanks!