### PR TITLE
Add mongo connection string uri support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You can also use the same config to keep multiple keys, the manager allows you a
 
 `mongodb-migrations` will try to load `config.ini` first, if it's not found, default values will be used. If any command line argument is provided, it will override config from configuration file.
 
-**Only database name is mandatory**
+**Database name or Url is mandatory**
 
 ### config.ini example
 
@@ -56,11 +56,24 @@ database = test
 migrations = migrations
 ```
 
+### alternative config.ini example
+```ini
+[mongo]
+url = mongodb://127.0.0.1:27017/test
+migrations = migrations
+```
+
 ### command line arguments example
 
 ```bash
 mongodb-migrate --host 127.0.0.1 --port 27017 --database test --migrations examples
 ```
+
+### alternative command line example
+```bash
+mongodb-migrate --url mongodb://127.0.0.1:27017/test --migrations examples
+```
+
 
 ## Example
 

--- a/mongodb_migrations/base.py
+++ b/mongodb_migrations/base.py
@@ -5,12 +5,15 @@ class BaseMigration(object):
     def __init__(self,
                  host='127.0.0.1',
                  port='27017',
-                 database=None):
-        if not database:
-            raise Exception('no database selected!')
-
-        client = pymongo.MongoClient(host=host, port=port)
-        self.db = client[database]
+                 database=None, url=None):
+        if url:
+            client = pymongo.MongoClient(url)
+            self.db = client.get_database()
+        elif database:
+            client = pymongo.MongoClient(host=host, port=port)
+            self.db = client[database]
+        else:
+            raise Exception('no database or url provided')
 
     def upgrade(self):
         raise NotImplementedError

--- a/mongodb_migrations/config.py
+++ b/mongodb_migrations/config.py
@@ -23,7 +23,7 @@ class Configuration(object):
         self._from_console()
 
         if all([self.mongo_url, self.mongo_database]) or not any([self.mongo_url, self.mongo_database]):
-            raise Exception("database name or connection string url must be provided but not both")
+            raise Exception("Once mongo_url is provided, none of host, port and database can be provided")
 
     def _from_console(self):
         self.arg_parser = argparse.ArgumentParser(description="Mongodb migration parser")

--- a/mongodb_migrations/config.py
+++ b/mongodb_migrations/config.py
@@ -3,14 +3,17 @@ import os
 from configparser import ConfigParser
 from enum import Enum
 
+
 class Execution(Enum):
     DOWNGRADE = 'execution_downgrade'
     MIGRATE = 'execution_migrate'
+
 
 class Configuration(object):
     config_file = os.getenv('MONGODB_MIGRATIONS_CONFIG', 'config.ini')
     mongo_host = '127.0.0.1'
     mongo_port = '27017'
+    mongo_url = None
     mongo_database = None
     mongo_migrations_path = 'migrations'
     execution = Execution.MIGRATE
@@ -19,33 +22,42 @@ class Configuration(object):
         self._from_ini()
         self._from_console()
 
-        if not self.mongo_database:
-            raise Exception("No database name is provided")
+        if all([self.mongo_url, self.mongo_database]) or not any([self.mongo_url, self.mongo_database]):
+            raise Exception("database name or connection string url must be provided but not both")
 
     def _from_console(self):
         self.arg_parser = argparse.ArgumentParser(description="Mongodb migration parser")
 
         self.arg_parser.add_argument('--host', metavar='H', default=self.mongo_host,
-                            help="host of MongoDB")
+                                     help="host of MongoDB")
         self.arg_parser.add_argument('--port', type=int, metavar='p', default=self.mongo_port,
-                            help="port of MongoDB")
+                                     help="port of MongoDB")
         self.arg_parser.add_argument('--database', metavar='d',
-                            help="database of MongoDB", required=(self.mongo_database==None), default=self.mongo_database)
+                                     help="database of MongoDB", default=self.mongo_database)
+        self.arg_parser.add_argument("--url", metavar='u',
+                                     help="Mongo Connection String URI", default=self.mongo_url)
         self.arg_parser.add_argument('--migrations', default=self.mongo_migrations_path,
-                            help="directory of migration files")
+                                     help="directory of migration files")
         self.arg_parser.add_argument('--downgrade', action='store_true',
-                            default=False, help='Downgrade instead of upgrade')
+                                     default=False, help='Downgrade instead of upgrade')
         args = self.arg_parser.parse_args()
 
+        if all([args.url, args.database]) or not any([args.url, args.database]):
+            self.arg_parser.error("--url or --database must be used but not both")
+
+        self.mongo_url = args.url
         self.mongo_host = args.host
         self.mongo_port = args.port
         self.mongo_database = args.database
         self.mongo_migrations_path = args.migrations
-        if args.downgrade == True:
+
+        if args.downgrade:
             self.execution = Execution.DOWNGRADE
 
     def _from_ini(self):
-        self.ini_parser = ConfigParser(defaults={'host': self.mongo_host, 'port': self.mongo_port, 'migrations': self.mongo_migrations_path, 'database': self.mongo_database})
+        self.ini_parser = ConfigParser(
+            defaults={'host': self.mongo_host, 'port': self.mongo_port, 'migrations': self.mongo_migrations_path,
+                      'database': self.mongo_database, 'url': self.mongo_url})
 
         try:
             fp = open(self.config_file)
@@ -57,6 +69,7 @@ class Configuration(object):
                 if not self.ini_parser.sections():
                     raise Exception("Cannot find %s or it doesn't have sections." % self.config_file)
 
+                self.mongo_url = self.ini_parser.get('mongo', 'url')
                 self.mongo_host = self.ini_parser.get('mongo', 'host')
                 self.mongo_port = self.ini_parser.getint('mongo', 'port')
                 self.mongo_database = self.ini_parser.get('mongo', 'database')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pymongo
 configparser
+enum34

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mongodb-migrations',
-    version='0.4.1',
+    version='0.5',
     description='A database migration tool for MongoDB',
     long_description=__doc__,
     url='https://github.com/DoubleCiti/mongodb-migrations',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mongodb-migrations',
-    version='0.5',
+    version='0.5.0',
     description='A database migration tool for MongoDB',
     long_description=__doc__,
     url='https://github.com/DoubleCiti/mongodb-migrations',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(
     zip_safe=False,
     install_requires=[
         'pymongo>=3.2.1',
-        'configparser==3.5.0'
+        'configparser==3.5.0',
+        'enum34==1.1.6',
     ],
     entry_points={
         'console_scripts': ['mongodb-migrate=mongodb_migrations.cli:main'],

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'pymongo==3.2.1',
+        'pymongo>=3.2.1',
         'configparser==3.5.0'
     ],
     entry_points={


### PR DESCRIPTION
My organization uses the mongo connection string uri in order to establish connections to mongo and it would be nice if we could use the same URI in this tool rather than having to parse the string to pull out the host, port, and database. It also will allow us to use additional connection string options like `mongodb://username:password@localhost:27017/test?authSource=authDB` or `mongodb://localhost:27017/test?connectTimeoutMS=300000&replicaSet=mySet`. Let me know what you think