### PR TITLE
Allow optional metastore name parameter| where to store migrations 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ MongoDB is a great NoSQL and schema-less database, but if already have data in d
 3. in `20160320145400_description.py` create a class named `Migration` and extends `BaseMigration`
 4. implement `upgrade` method
 5. use cli `mongodb-migrate` to run migrations
+6. `metastore` is an optional parameter of collection name where it stores the previous migrations
 
 If you don't wish to use the CLI, you can override the MigrationManager -> create_config and then call MigrationManager -> run. Example execution:
 
@@ -54,6 +55,7 @@ host = 127.0.0.1
 port = 27017
 database = test
 migrations = migrations
+metastore = database_migrations
 ```
 
 ### alternative config.ini example

--- a/mongodb_migrations/cli.py
+++ b/mongodb_migrations/cli.py
@@ -89,14 +89,14 @@ class MigrationManager(object):
                 self._remove_migration(migration_datetime)
 
     def _get_migration_names(self):
-        return self.db.database_migrations.find().sort('migration_datetime', pymongo.DESCENDING)
+        return self.db[self.config.metastore].find().sort('migration_datetime', pymongo.DESCENDING)
 
     def _create_migration(self, migration_datetime):
-        self.db.database_migrations.save({'migration_datetime': migration_datetime,
+        self.db[self.config.metastore].save({'migration_datetime': migration_datetime,
                                           'created_at': datetime.now()})
 
     def _remove_migration(self, migration_datetime):
-        self.db.database_migrations.remove({'migration_datetime': migration_datetime})
+        self.db[self.config.metastore].remove({'migration_datetime': migration_datetime})
 
     def _get_mongo_database(self, host, port, database, url):
         if url:

--- a/mongodb_migrations/config.py
+++ b/mongodb_migrations/config.py
@@ -16,6 +16,7 @@ class Configuration(object):
     mongo_url = ''
     mongo_database = ''
     mongo_migrations_path = 'migrations'
+    metastore = 'database_migrations'
     execution = Execution.MIGRATE
 
     def __init__(self):
@@ -40,6 +41,8 @@ class Configuration(object):
                                      help="directory of migration files")
         self.arg_parser.add_argument('--downgrade', action='store_true',
                                      default=False, help='Downgrade instead of upgrade')
+        self.arg_parser.add_argument('--metastore', default="database_migrations",
+                                     help='Where to store db migrations')
         args = self.arg_parser.parse_args()
 
         if all([args.url, args.database]) or not any([args.url, args.database]):
@@ -50,6 +53,7 @@ class Configuration(object):
         self.mongo_port = args.port
         self.mongo_database = args.database
         self.mongo_migrations_path = args.migrations
+        self.metastore = args.metastore
 
         if args.downgrade:
             self.execution = Execution.DOWNGRADE
@@ -57,7 +61,8 @@ class Configuration(object):
     def _from_ini(self):
         self.ini_parser = ConfigParser(
             defaults={'host': self.mongo_host, 'port': self.mongo_port, 'migrations': self.mongo_migrations_path,
-                      'database': self.mongo_database, 'url': self.mongo_url})
+                      'database': self.mongo_database, 'url': self.mongo_url, 
+                      'metastore': self.metastore})
 
         try:
             fp = open(self.config_file)
@@ -74,3 +79,4 @@ class Configuration(object):
                 self.mongo_port = self.ini_parser.getint('mongo', 'port')
                 self.mongo_database = self.ini_parser.get('mongo', 'database')
                 self.mongo_migrations_path = self.ini_parser.get('mongo', 'migrations')
+                self.metastore = self.ini_parser.get('mongo', 'metastore')


### PR DESCRIPTION
adding support or to add an optional metastore parameter to specify where the migrations will be stored. For maintaining backwards compatibility it is defaulted to use `database_migrations` collections. 