### PR TITLE
support for authdb added

### DIFF
--- a/mongodb_migrations/base.py
+++ b/mongodb_migrations/base.py
@@ -5,12 +5,12 @@ class BaseMigration(object):
     def __init__(self,
                  host='127.0.0.1',
                  port='27017',
-                 database=None,                 
-                 auth_user=None,
-                 auth_password=None,
+                 database=None,
+                 user=None,
+                 password=None,
                  url=None):
-        if url and database and auth_user is not None: #provide auth_database in url (mongodb://mongohostname:27017/auth_database)
-            client = pymongo.MongoClient(url, username=auth_user, password=auth_password)
+        if url and database and user is not None: #provide auth_database in url (mongodb://mongohostname:27017/auth_database)
+            client = pymongo.MongoClient(url, username=user, password=password)
             self.db = client.get_database(database)
         elif url:
             client = pymongo.MongoClient(url)

--- a/mongodb_migrations/base.py
+++ b/mongodb_migrations/base.py
@@ -5,16 +5,21 @@ class BaseMigration(object):
     def __init__(self,
                  host='127.0.0.1',
                  port='27017',
-                 database=None,
+                 database=None,                 
+                 auth_user=None,
+                 auth_password=None,
                  url=None):
-        if url:
+        if url and database and auth_user is not None: #provide auth_database in url (mongodb://mongohostname:27017/auth_database)
+            client = pymongo.MongoClient(url, username=auth_user, password=auth_password)
+            self.db = client.get_database(database)
+        elif url:
             client = pymongo.MongoClient(url)
             self.db = client.get_default_database()
         elif database:
             client = pymongo.MongoClient(host=host, port=port)
             self.db = client[database]
         else:
-            raise Exception('no database or url provided')
+            raise Exception('no database, url or auth_database in url provided')
 
     def upgrade(self):
         raise NotImplementedError

--- a/mongodb_migrations/cli.py
+++ b/mongodb_migrations/cli.py
@@ -25,7 +25,7 @@ class MigrationManager(object):
 
     def run(self):
         self.db = self._get_mongo_database(self.config.mongo_host, self.config.mongo_port, self.config.mongo_database,
-                                           self.config.mongo_auth_user, self.config.mongo_auth_password,
+                                           self.config.mongo_username, self.config.mongo_password,
                                            self.config.mongo_url)
         files = os.listdir(self.config.mongo_migrations_path)
         for file in files:
@@ -57,9 +57,9 @@ class MigrationManager(object):
                     module = __import__(self.migrations[migration_datetime])
                     migration_object = module.Migration(host=self.config.mongo_host,
                                                         port=self.config.mongo_port,
-                                                        database=self.config.mongo_database,                                                        
-                                                        auth_user=self.config.mongo_auth_user,
-                                                        auth_password=self.config.mongo_auth_password,
+                                                        database=self.config.mongo_database,
+                                                        user=self.config.mongo_username,
+                                                        password=self.config.mongo_password,
                                                         url=self.config.mongo_url)
                     migration_object.upgrade()
                 except Exception as e:
@@ -79,9 +79,9 @@ class MigrationManager(object):
                     module = __import__(self.migrations[migration_datetime])
                     migration_object = module.Migration(host=self.config.mongo_host,
                                                         port=self.config.mongo_port,
-                                                        database=self.config.mongo_database,                                                        
-                                                        auth_user=self.config.mongo_auth_user,
-                                                        auth_password=self.config.mongo_auth_password,
+                                                        database=self.config.mongo_database,
+                                                        user=self.config.mongo_username,
+                                                        password=self.config.mongo_password,
                                                         url=self.config.mongo_url)
                     migration_object.downgrade()
                 except Exception as e:
@@ -103,9 +103,9 @@ class MigrationManager(object):
     def _remove_migration(self, migration_datetime):
         self.db[self.config.metastore].remove({'migration_datetime': migration_datetime})
 
-    def _get_mongo_database(self, host, port, database, auth_user, auth_password, url):
-        if url and database and auth_user is not None: #provide auth_database in url (mongodb://mongohostname:27017/auth_database)
-            client = pymongo.MongoClient(url, user=auth_user, password=auth_password)
+    def _get_mongo_database(self, host, port, database, user, password, url):
+        if url and database and user is not None: #provide auth_database in url (mongodb://mongohostname:27017/auth_database)
+            client = pymongo.MongoClient(url, username=user, password=password)
             return client.get_database(database)
         elif url:
             client = pymongo.MongoClient(url)

--- a/mongodb_migrations/config.py
+++ b/mongodb_migrations/config.py
@@ -14,9 +14,9 @@ class Configuration(object):
     mongo_host = '127.0.0.1'
     mongo_port = '27017'
     mongo_url = ''
-    mongo_database = ''    
-    mongo_auth_user = ''
-    mongo_auth_password = ''
+    mongo_database = ''
+    mongo_username = ''
+    mongo_password = ''
     mongo_migrations_path = 'migrations'
     metastore = 'database_migrations'
     execution = Execution.MIGRATE
@@ -37,10 +37,10 @@ class Configuration(object):
                                      help="port of MongoDB")
         self.arg_parser.add_argument('--database', metavar='d',
                                      help="database of MongoDB", default=self.mongo_database)        
-        self.arg_parser.add_argument('--authuser', metavar='au',
-                                     help="username for auth database of MongoDB", default=self.mongo_auth_user)
-        self.arg_parser.add_argument('--authpw', metavar='p',
-                                     help="password for auth database of MongoDB", default=self.mongo_auth_password)
+        self.arg_parser.add_argument('--username', metavar='U',
+                                     help="username for auth database of MongoDB", default=self.mongo_username)
+        self.arg_parser.add_argument('--password', metavar='p',
+                                     help="password for auth database of MongoDB", default=self.mongo_password)
         self.arg_parser.add_argument("--url", metavar='u',
                                      help="Mongo Connection String URI", default=self.mongo_url)
         self.arg_parser.add_argument('--migrations', default=self.mongo_migrations_path,
@@ -51,15 +51,16 @@ class Configuration(object):
                                      help='Where to store db migrations')
         args = self.arg_parser.parse_args()
 
+        # TODO: change to accept url and database for auth_database scenario
         if all([args.url, args.database]) or not any([args.url, args.database]):
             self.arg_parser.error("--url or --database must be used but not both")
 
         self.mongo_url = args.url
         self.mongo_host = args.host
         self.mongo_port = args.port
-        self.mongo_database = args.database        
-        self.mongo_auth_user = args.mongo_auth_user
-        self.mongo_auth_password = args.mongo_auth_password
+        self.mongo_database = args.database
+        self.mongo_username = args.mongo_username
+        self.mongo_password = args.mongo_password
         self.mongo_migrations_path = args.migrations
         self.metastore = args.metastore
 
@@ -69,9 +70,9 @@ class Configuration(object):
     def _from_ini(self):
         self.ini_parser = ConfigParser(
             defaults={'host': self.mongo_host, 'port': self.mongo_port, 'migrations': self.mongo_migrations_path,
-                      'database': self.mongo_database,                      
-                      'auth_user': self.mongo_auth_user,
-                      'auth_password': self.mongo_auth_password,
+                      'database': self.mongo_database,
+                      'username': self.mongo_username,
+                      'password': self.mongo_password,
                       'url': self.mongo_url, 
                       'metastore': self.metastore})
 
@@ -88,8 +89,8 @@ class Configuration(object):
                 self.mongo_url = self.ini_parser.get('mongo', 'url')
                 self.mongo_host = self.ini_parser.get('mongo', 'host')
                 self.mongo_port = self.ini_parser.getint('mongo', 'port')
-                self.mongo_database = self.ini_parser.get('mongo', 'database')                
-                self.mongo_auth_user = self.ini_parser.get('mongo', 'auth_user')
-                self.mongo_auth_password = self.ini_parser.get('mongo', 'auth_password')
+                self.mongo_database = self.ini_parser.get('mongo', 'database')
+                self.mongo_username = self.ini_parser.get('mongo', 'username')
+                self.mongo_password = self.ini_parser.get('mongo', 'password')
                 self.mongo_migrations_path = self.ini_parser.get('mongo', 'migrations')
                 self.metastore = self.ini_parser.get('mongo', 'metastore')

--- a/mongodb_migrations/config.py
+++ b/mongodb_migrations/config.py
@@ -14,7 +14,9 @@ class Configuration(object):
     mongo_host = '127.0.0.1'
     mongo_port = '27017'
     mongo_url = ''
-    mongo_database = ''
+    mongo_database = ''    
+    mongo_auth_user = ''
+    mongo_auth_password = ''
     mongo_migrations_path = 'migrations'
     metastore = 'database_migrations'
     execution = Execution.MIGRATE
@@ -22,9 +24,9 @@ class Configuration(object):
     def __init__(self):
         self._from_ini()
         self._from_console()
-
-        if all([self.mongo_url, self.mongo_database]) or not any([self.mongo_url, self.mongo_database]):
-            raise Exception("Once mongo_url is provided, none of host, port and database can be provided")
+        # TODO: change to accept url and database for auth_database scenario
+        #if all([self.mongo_url, self.mongo_database]) or not any([self.mongo_url, self.mongo_database]):
+        #    raise Exception("Once mongo_url is provided, none of host, port and database can be provided")
 
     def _from_console(self):
         self.arg_parser = argparse.ArgumentParser(description="Mongodb migration parser")
@@ -34,7 +36,11 @@ class Configuration(object):
         self.arg_parser.add_argument('--port', type=int, metavar='p', default=self.mongo_port,
                                      help="port of MongoDB")
         self.arg_parser.add_argument('--database', metavar='d',
-                                     help="database of MongoDB", default=self.mongo_database)
+                                     help="database of MongoDB", default=self.mongo_database)        
+        self.arg_parser.add_argument('--authuser', metavar='au',
+                                     help="username for auth database of MongoDB", default=self.mongo_auth_user)
+        self.arg_parser.add_argument('--authpw', metavar='p',
+                                     help="password for auth database of MongoDB", default=self.mongo_auth_password)
         self.arg_parser.add_argument("--url", metavar='u',
                                      help="Mongo Connection String URI", default=self.mongo_url)
         self.arg_parser.add_argument('--migrations', default=self.mongo_migrations_path,
@@ -51,7 +57,9 @@ class Configuration(object):
         self.mongo_url = args.url
         self.mongo_host = args.host
         self.mongo_port = args.port
-        self.mongo_database = args.database
+        self.mongo_database = args.database        
+        self.mongo_auth_user = args.mongo_auth_user
+        self.mongo_auth_password = args.mongo_auth_password
         self.mongo_migrations_path = args.migrations
         self.metastore = args.metastore
 
@@ -61,7 +69,10 @@ class Configuration(object):
     def _from_ini(self):
         self.ini_parser = ConfigParser(
             defaults={'host': self.mongo_host, 'port': self.mongo_port, 'migrations': self.mongo_migrations_path,
-                      'database': self.mongo_database, 'url': self.mongo_url, 
+                      'database': self.mongo_database,                      
+                      'auth_user': self.mongo_auth_user,
+                      'auth_password': self.mongo_auth_password,
+                      'url': self.mongo_url, 
                       'metastore': self.metastore})
 
         try:
@@ -77,6 +88,8 @@ class Configuration(object):
                 self.mongo_url = self.ini_parser.get('mongo', 'url')
                 self.mongo_host = self.ini_parser.get('mongo', 'host')
                 self.mongo_port = self.ini_parser.getint('mongo', 'port')
-                self.mongo_database = self.ini_parser.get('mongo', 'database')
+                self.mongo_database = self.ini_parser.get('mongo', 'database')                
+                self.mongo_auth_user = self.ini_parser.get('mongo', 'auth_user')
+                self.mongo_auth_password = self.ini_parser.get('mongo', 'auth_password')
                 self.mongo_migrations_path = self.ini_parser.get('mongo', 'migrations')
                 self.metastore = self.ini_parser.get('mongo', 'metastore')

--- a/mongodb_migrations/config.py
+++ b/mongodb_migrations/config.py
@@ -39,7 +39,7 @@ class Configuration(object):
                                      help="database of MongoDB", default=self.mongo_database)        
         self.arg_parser.add_argument('--username', metavar='U',
                                      help="username for auth database of MongoDB", default=self.mongo_username)
-        self.arg_parser.add_argument('--password', metavar='p',
+        self.arg_parser.add_argument('--password', metavar='P',
                                      help="password for auth database of MongoDB", default=self.mongo_password)
         self.arg_parser.add_argument("--url", metavar='u',
                                      help="Mongo Connection String URI", default=self.mongo_url)


### PR DESCRIPTION
Hi,
I added support for auth-db with username and password, auth-db name is provided via url string.
Only base.py, cli.py and config.py in mongodb-migrations subfolder have been changed.

TODO:
- Handle exception in __init__ (config.py)
- check if migrations are working with auth-db