### PR TITLE
authdb fix in config.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ url = mongodb://127.0.0.1:27017/test
 migrations = migrations
 ```
 
+### auth-db config.ini example
+```ini
+[mongo]
+url = mongodb://127.0.0.1:27017/admin
+username = admin
+password = secret123
+database = test
+migrations = migrations
+metastore = database_migrations
+```
+
 ### command line arguments example
 
 ```bash

--- a/mongodb_migrations/config.py
+++ b/mongodb_migrations/config.py
@@ -52,8 +52,8 @@ class Configuration(object):
         args = self.arg_parser.parse_args()
 
         # TODO: change to accept url and database for auth_database scenario
-        if all([args.url, args.database]) or not any([args.url, args.database]):
-            self.arg_parser.error("--url or --database must be used but not both")
+        #if all([args.url, args.database]) or not any([args.url, args.database]):
+        #    self.arg_parser.error("--url or --database must be used but not both")
 
         self.mongo_url = args.url
         self.mongo_host = args.host

--- a/mongodb_migrations/config.py
+++ b/mongodb_migrations/config.py
@@ -36,7 +36,7 @@ class Configuration(object):
         self.arg_parser.add_argument('--port', type=int, metavar='p', default=self.mongo_port,
                                      help="port of MongoDB")
         self.arg_parser.add_argument('--database', metavar='d',
-                                     help="database of MongoDB", default=self.mongo_database)        
+                                     help="database of MongoDB", default=self.mongo_database)
         self.arg_parser.add_argument('--username', metavar='U',
                                      help="username for auth database of MongoDB", default=self.mongo_username)
         self.arg_parser.add_argument('--password', metavar='P',
@@ -59,8 +59,8 @@ class Configuration(object):
         self.mongo_host = args.host
         self.mongo_port = args.port
         self.mongo_database = args.database
-        self.mongo_username = args.mongo_username
-        self.mongo_password = args.mongo_password
+        self.mongo_username = args.username
+        self.mongo_password = args.password
         self.mongo_migrations_path = args.migrations
         self.metastore = args.metastore
 


### PR DESCRIPTION
I fixed a bug and commented another part not yet implemented, both in config.py :)

Bugfix:

    self.mongo_username = args.mongo_username
    self.mongo_password = args.mongo_password

TO

     self.mongo_username = args.username
     self.mongo_password = args.password

Lines commented due to missing implementation:

    # TODO: change to accept url and database for auth_database scenario
    #if all([args.url, args.database]) or not any([args.url, args.database]):
    #    self.arg_parser.error("--url or --database must be used but not both")

Now the "in code migration" via

    manager = cli.MigrationManager()
    manager.config.config_file = "config.ini"
    manager.config._from_ini()
    manager.run()

is working perfectly fine. :)

PLEASE ACCEPT THIS REQUEST including "authdb fix in config.py" and "variable name fixes in config.py" ! :)