### PR TITLE
unpin dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ setup(
     zip_safe=False,
     install_requires=[
         'pymongo>=3.2.1',
-        'configparser==3.5.0',
-        'enum34==1.1.6',
+        'configparser>=3.5.0',
+        'enum34>=1.1.6',
     ],
     entry_points={
         'console_scripts': ['mongodb-migrate=mongodb_migrations.cli:main'],


### PR DESCRIPTION
Dependency pinning in packages proves problematic when installing inside a larger projects as one clash of dependencies automatically makes installation impossible. At the same time is unlikely that standard library backports (enum34, configparser) will introduce backward incompatible changes that will break this project.