### PR TITLE
Made ArgumentParser parsing only inside `main`

### DIFF
--- a/mongodb_migrations/cli.py
+++ b/mongodb_migrations/cli.py
@@ -20,8 +20,8 @@ class MigrationManager(object):
     migrations = {}
     database_migration_names = None
 
-    def __init__(self):
-        self.config = Configuration()
+    def __init__(self, config):
+        self.config = config
 
     def run(self):
         self.db = self._get_mongo_database(self.config.mongo_host, self.config.mongo_port, self.config.mongo_database,
@@ -118,5 +118,7 @@ class MigrationManager(object):
 
 
 def main():
-    manager = MigrationManager()
+    config = Configuration()
+    config.from_console()
+    manager = MigrationManager(config)
     manager.run()

--- a/mongodb_migrations/cli.py
+++ b/mongodb_migrations/cli.py
@@ -20,7 +20,7 @@ class MigrationManager(object):
     migrations = {}
     database_migration_names = None
 
-    def __init__(self, config):
+    def __init__(self, config=Configuration()):
         self.config = config
 
     def run(self):

--- a/mongodb_migrations/config.py
+++ b/mongodb_migrations/config.py
@@ -23,12 +23,11 @@ class Configuration(object):
 
     def __init__(self):
         self._from_ini()
-        self._from_console()
         # TODO: change to accept url and database for auth_database scenario
         #if all([self.mongo_url, self.mongo_database]) or not any([self.mongo_url, self.mongo_database]):
         #    raise Exception("Once mongo_url is provided, none of host, port and database can be provided")
 
-    def _from_console(self):
+    def from_console(self):
         self.arg_parser = argparse.ArgumentParser(description="Mongodb migration parser")
 
         self.arg_parser.add_argument('--host', metavar='H', default=self.mongo_host,


### PR DESCRIPTION
Hello guys, first time here 👋

I'd like to programmatically invoke migrations inside a `Flask` app, unfortunately there was no way avoiding calls to `ArgumentParser.add_argument` which causes quite some problems inside a `Flask+Click` command app. I can provide examples.

My suggestion here: let the `Config` object make use of the `ArgumentParser` *only* when the tool is invoked through the `mongodb-migrate` entrypoint. I think this is also a good thing to have in general.