### PR TITLE
Replace deprecated collection.save method

### DIFF
--- a/mongodb_migrations/cli.py
+++ b/mongodb_migrations/cli.py
@@ -101,7 +101,7 @@ class MigrationManager(object):
         return self.db[self.config.metastore].find().sort('migration_datetime', pymongo.DESCENDING)
 
     def _create_migration(self, migration_datetime):
-        self.db[self.config.metastore].save({'migration_datetime': migration_datetime,
+        self.db[self.config.metastore].insert_one({'migration_datetime': migration_datetime,
                                           'created_at': datetime.now()})
 
     def _remove_migration(self, migration_datetime):


### PR DESCRIPTION
As stated in [Issue#38](https://github.com/DoubleCiti/mongodb-migrations/issues/38):

Starting in MongoDB 4.2, the db.collection.save() method is deprecated. The alternative is to use db.collection.insertOne() or db.collection.replaceOne() instead.

So this PR replaces the collection.save() method in favor of collection.insert_one() to keep the library compatible with the new release of pymongo 4.0 https://pymongo.readthedocs.io/en/stable/changelog.html#breaking-changes-in-4-0