### PR TITLE
Refrain from updating metastore when doing a dry run (#48)

### DIFF
--- a/mongodb_migrations/cli.py
+++ b/mongodb_migrations/cli.py
@@ -97,7 +97,8 @@ class MigrationManager(object):
                         print(e.message)
                     raise
                 print("Succeed to upgrade version: %s" % self.migrations[migration_datetime])
-                self._create_migration(migration_datetime)
+                if not self.config.dry_run:
+                    self._create_migration(migration_datetime)
 
     def _do_rollback(self, to_datetime=None):
         for migration_datetime in sorted(self.database_migration_names, reverse=True):
@@ -122,7 +123,8 @@ class MigrationManager(object):
                         print(e.message)
                     raise
                 print("Succeed to downgrade version: %s" % self.migrations[migration_datetime])
-                self._remove_migration(migration_datetime)
+                if not self.config.dry_run:
+                    self._remove_migration(migration_datetime)
 
     def _get_migration_names(self):
         return self.db[self.config.metastore].find().sort('migration_datetime', pymongo.DESCENDING)


### PR DESCRIPTION
In this branch, I made it so the script doesn't update the metastore when the script is in `--dry-run` mode.

This branch contains the changes I think will fix issue #48. However, I have not **tested** these changes. I don't have experience modifying third-party Python packages (e.g. those installed via `pip`) and don't have the spare time today to learn how to do that. If, when I have spare time, I see this branch hasn't been merged yet, I'll learn how to do that and then post my test results. Meanwhile, I wanted to get the changes out there so people have the opportunity to test them.