### PR TITLE
fix python 3.12 compatibility

### DIFF
--- a/mongodb_migrations/config.py
+++ b/mongodb_migrations/config.py
@@ -107,7 +107,7 @@ class Configuration(object):
             pass
         else:
             with fp:
-                self.ini_parser.readfp(fp)
+                self.ini_parser.read_file(fp)
                 if not self.ini_parser.sections():
                     raise Exception("Cannot find %s or it doesn't have sections." % self.config_file)
 


### PR DESCRIPTION
See issue over here: https://github.com/DoubleCiti/mongodb-migrations/issues/52

Maybe @darth30joker can have a look at it & release a new version, so I can use it with my team?