### PR TITLE
Fix SyntaxWarning

### DIFF
--- a/mongodb_migrations/cli.py
+++ b/mongodb_migrations/cli.py
@@ -29,7 +29,7 @@ class MigrationManager(object):
                                            self.config.mongo_url)
         files = os.listdir(self.config.mongo_migrations_path)
         for file in files:
-            result = re.match('^(\d+)[_a-z]*\.py$', file)
+            result = re.match(r'^(\d+)[_a-z]*\.py$', file)
             if result:
                 self.migrations[result.group(1)] = file[:-3]
 


### PR DESCRIPTION
Fixes #54 

```
mongodb_migrations/cli.py:32: SyntaxWarning: invalid escape sequence '\d'
17:04:28      result = re.match('^(\d+)[_a-z]*\.py$', file)
```